### PR TITLE
[UIMA-6380] Maven plugin plugin from parent pom not compatible with Java 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
           <executions>
             <execution>
               <!-- force to use process-classes phase so runs after Java Annotations are available -->


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6380

**What's in the PR**
- Upgrade Maven Plugin Plugin version for Java 16 compatibility

**How to test manually**
* E.g. upgrade UIMA Java SDK to use this parent pom and then build on Java 16

**Automatic testing**
* [ ] *PR adds/updates unit tests*

**Documentation**
* [ ] *PR adds/updates documentation*

**Organizational**
- [ ] *PR includes new dependencies.* Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed.
      LICENSE and NOTICE files in the respective modules where dependencies have been added as
      well as in the project root have been updated.
