### PR TITLE
[UIMA-6439] Release build signs some 'sha512' files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,8 +821,6 @@
                       <then>
                         <echo message="Generating checksums for source-release.zip" />
                         <checksum format="MD5SUM" forceoverwrite="yes" algorithm="SHA-512" fileext=".sha512" file="${source-release}" />
-                        <!-- <checksum format="MD5SUM" forceoverwrite="yes" algorithm="sha1" file="${source-release}" /> -->
-                        <!-- <checksum format="MD5SUM" forceoverwrite="yes" algorithm="md5" file="${source-release}" />  -->
                         <echo message="Generating gpg signatures for source-release.zip" />
                         <exec executable="gpg" failonerror="true">
                           <arg value="--detach-sign" />
@@ -856,7 +854,7 @@
                 <id>sign-release-artifacts</id>
                 <configuration>
                   <excludes>
-                    <!--  <exclude>**/*.sha512</exclude>  https://issues.apache.org/jira/browse/UIMA-5897 -->
+                    <exclude>**/*.sha512</exclude>
                     <exclude>**/*.asc</exclude>
                   </excludes>
                 </configuration>
@@ -1828,8 +1826,6 @@
                     <delete dir="${eusWork}">
                       <include name="**/*.asc" />
                       <include name="**/*.sha512" />
-                      <!-- include name="**/*.md5" /-->
-                      <!-- <include name="**/*.sha1" /> -->
                     </delete>
 
                     <echo message="Generating checksums for signed plugins" />
@@ -1857,8 +1853,6 @@
                       <fileset dir="${eusWork}">
                         <include name="**/*.asc" />
                         <include name="**/*.sha512" />
-                        <!-- include name="**/*.md5" /-->
-                        <!-- <include name="**/*.sha1" /> -->
                       </fileset>
                     </copy>
 
@@ -1868,8 +1862,6 @@
                     <delete dir="${eclipseUpdateSubSite}">
                       <include name="*.asc" />
                       <include name="*.sha512" />
-                      <!-- <include name="*.md5" /> -->
-                      <!-- <include name="*.sha1" /> -->
                     </delete>
 
                     <echo message="Generating checksums for updated artifacts.jar and content.jar" />


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6439

**What's in the PR**
- Add exclude for signing `.sha512` files - we do not need to sign these

**How to test manually**
* Run build of a downstream project

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
