### PR TITLE
[UIMA-6458] Spurious "parsedVersion.osgiVersion" in file names in target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,17 +420,15 @@
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.1.0</version>
           <dependencies>
+            <dependency>
+              <groupId>org.apache.ant</groupId>
+              <artifactId>ant</artifactId>
+              <version>1.10.12</version>
+            </dependency>
             <dependency> <!-- for ant extension supporting "if" -->
               <groupId>ant-contrib</groupId>
               <artifactId>ant-contrib</artifactId>
               <version>20020829</version>
-              <scope>runtime</scope>
-              <exclusions>
-                <exclusion> <!-- is dragging in ant 1.5 -->
-                  <groupId>ant</groupId>
-                  <artifactId>ant</artifactId>
-                </exclusion>
-              </exclusions>
             </dependency>
             <!-- <containsregexp> form for filesets -->
             <dependency>
@@ -444,7 +442,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.5</version>
+          <version>5.1.6</version>
           <extensions>true</extensions>
           <executions>
             <execution>
@@ -795,16 +793,27 @@
                         </fixcrlf>
                       </then>
                     </if>
-                    
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-pom-to-target</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
                     <!-- FIXME: Why do the checksum on the POM? I think this can be removed -->
                     <!-- copy to target so checksum-maven-plugin can sha512 checkum it -->
-                    <property name="pom-file-tgt" location="${project.build.directory}/${project.build.finalName}.pom" />
-                    <property name="pom-file-src" location="${project.build.directory}/../pom.xml" />
+                    <property name="pom-file-tgt"
+                      location="${project.build.directory}/${project.artifactId}-${project.version}.pom" />
+                    <property name="pom-file-src"
+                      location="${project.build.directory}/../pom.xml" />
                     <copy file="${pom-file-src}" tofile="${pom-file-tgt}" />
                   </target>
                 </configuration>
               </execution>
-
               <execution>
                 <id>sign and checksum source-release.zip</id>
                 <phase>verify</phase>  <!-- after source-release is built -->
@@ -814,12 +823,14 @@
                 <configuration>
                   <target>
                     <taskdef name="if" classname="net.sf.antcontrib.logic.IfTask" />
-                    <property name="source-release" location="${project.build.directory}/${project.artifactId}-${project.version}-source-release.zip" />
+                    <property name="source-release"
+                      location="${project.build.directory}/${project.artifactId}-${project.version}-source-release.zip" />
                     <if>
                       <available file="${source-release}" />
                       <then>
                         <echo message="Generating checksums for source-release.zip" />
-                        <checksum format="MD5SUM" forceoverwrite="yes" algorithm="SHA-512" fileext=".sha512" file="${source-release}" />
+                        <checksum format="MD5SUM" forceoverwrite="yes" algorithm="SHA-512"
+                          fileext=".sha512" file="${source-release}" />
                         <echo message="Generating gpg signatures for source-release.zip" />
                         <exec executable="gpg" failonerror="true">
                           <arg value="--detach-sign" />
@@ -876,6 +887,48 @@
                   <algorithms>
                     <algorithm>SHA-512</algorithm>
                   </algorithms>
+                </configuration>
+              </execution>
+              <execution>
+                <id>pom-checksum</id>
+                <goals>
+                  <goal>files</goal>
+                </goals>
+                <configuration>
+                  <appendFilename>true</appendFilename>
+                  <algorithms>
+                    <algorithm>SHA-512</algorithm>
+                  </algorithms>
+                  <fileSets>
+                    <fileSet>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}.pom</include>
+                      </includes>
+                    </fileSet>
+                  </fileSets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}.pom.sha512</file>
+                      <type>pom.sha512</type>
+                    </artifact>
+                  </artifacts>
                 </configuration>
               </execution>
             </executions>
@@ -1290,16 +1343,6 @@
         </file>
       </activation>
       <build>
-        <!-- The final name is typically overridden in the individual project
-             to follow the Eclipse naming rules.  Rather than just the artifactId,
-             Eclipse wants this name to be the same as the Bundle-SymbolicName,
-             which typically starts with org.apache.uima, and isn't the same as
-             the artifact name.
-             examples:
-                uimaj-ep-jcasgen    -     org.apache.uima.jcas.jcasgenp
-                uimaj-ep-configurator -   org.apache.uima.desceditor     -->
-        <finalName>${project.artifactId}_${parsedVersion.osgiVersion}</finalName>         
-                
         <!-- resources are "merged" -->
         <!-- needed to copy resources, icons, and the plugin.xml to the result -->
         <resources>
@@ -1424,7 +1467,6 @@
         </file>
       </activation>
       <build>
-        <finalName>${project.artifactId}_${parsedVersion.osgiVersion}</finalName>
         <!-- turn on filtering for these resources -->
         <resources>
           <resource>


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6458

**What's in the PR**
- Remove "finalName" from the Eclipse/OSGi modules
- maven-bundle-plugin 5.1.5 -> 5.1.5
- Add calculation and attachment of SHA512 checksum to the POM

**How to test manually**
* Do a product release build
* Check that hashes and signatures are properly generated
* Build an Eclipse update site and check it installs properly and can be used

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
