### PR TITLE
[UIMA-6460] move tycho and auto staging to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2849,8 +2849,8 @@
       </properties>
       <dependencies>
         <!--
-          - java.xml.bind and javax.annotation-api have been removed in Java 11 from the JDK, need to add it 
-          as dependency
+          - java.xml.bind and javax.annotation-api have been removed in Java 11 from the JDK, need 
+          - to add them as dependencies
         -->
         <dependency>
           <groupId>javax.xml.bind</groupId>
@@ -2880,6 +2880,21 @@
       <build>
         <pluginManagement>
           <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <configuration>
+                <ignoredUnusedDeclaredDependencies combine.children="append">
+                  <!--
+                    - JAXB is used via reflection and cannot be detected by Maven
+                  -->
+                  <dependency>javax.xml.bind:jaxb-api</dependency>
+                  <dependency>com.sun.xml.bind:jaxb-core</dependency>
+                  <dependency>com.sun.xml.bind:jaxb-impl</dependency>
+                  <dependency>javax.activation:javax.activation-api</dependency>
+                </ignoredUnusedDeclaredDependencies>
+              </configuration>
+            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2871,9 +2871,9 @@
           <scope>runtime</scope>
         </dependency>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+          <version>1.2.0</version>
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6460

**What's in the PR**
* Exclude JAXB from the maven dependency plugin
* Should have been "activation" not "annotation" when adding JAXB-related stuff to Java 11 builds

**How to test manually**
* Run downstream build

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
