### PR TITLE
Issue #26: Profile for OSGI bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2176,6 +2176,85 @@
     <!-- *   Build OSGi bundle            * -->
     <!-- ********************************** -->
     <profile>
+      <id>osgi-bundle</id>
+      <activation>
+        <file>
+          <exists>marker-file-identifying-osgi-bundle</exists>
+        </file>
+      </activation>
+      <build>
+         <plugins>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>5.1.6</version>
+            <extensions>true</extensions>
+            <configuration>
+              <instructions>
+                <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                <_dsannotations>*</_dsannotations>
+                <_metatypeannotations>*</_metatypeannotations>
+              </instructions>
+            </configuration>
+            <executions>
+              <execution>
+                <id>bundle-manifest</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>manifest</goal>
+                </goals>
+                <configuration>
+                  <niceManifest>true</niceManifest>
+                  <exportScr>true</exportScr>
+                  <scrLocation>${project.basedir}/OSGI-INF/..</scrLocation>
+                  <manifestLocation>${project.basedir}/META-INF</manifestLocation>
+                  <!-- 
+                    - Enabling this currently seems to cause spurious exceptions in Eclipse 
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                    -->
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+    
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>3.2.0</version>
+            <executions>
+              <execution>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+                <id>clean-manifest-and-osgiinf</id>
+                <configuration>
+                  <filesets>
+                    <fileset>
+                      <directory>${project.basedir}/META-INF</directory>
+                      <includes>
+                        <include>**</include>
+                      </includes>
+                    </fileset>
+                    <fileset>
+                      <directory>${project.basedir}/OSGI-INF</directory>
+                      <includes>
+                        <include>**</include>
+                      </includes>
+                    </fileset>
+                  </filesets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- ********************************** -->
+    <!-- *   Build OSGi bundle (old)      * -->
+    <!-- ********************************** -->
+    <profile>
       <id>build OSGi bundle for annotator</id>
       <activation>
         <file>


### PR DESCRIPTION
**What's in the PR**
- Added profile based on the Maven Bundle Plugin
- Profile stages META-INF and OSGI-INF in places where Eclipse PDE expects them so Eclipse would recognize them as bundles
- These locations are also cleaned up on a "clean"

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
