### PR TITLE
Issue #28: Upgrade plugins

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-XXXX
-
 **What's in the PR**
 * ...
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
   <!-- ============================================= -->
     <maven.version>3.6.3</maven.version>
     <!-- Tycho requires at least Java 11 -->
-    <javaVersionMinBuild>11</javaVersionMinBuild>
+    <javaVersionMinBuild>17</javaVersionMinBuild>
     <felix.bundle.version>3.3.0</felix.bundle.version>
 
     <maven.surefire.heap>512m</maven.surefire.heap>
@@ -514,6 +514,7 @@
               <configuration>
                 <consoleOutput>true</consoleOutput>
                 <excludes>
+                  <exclude>**/.gitattributes</exclude>
                   <exclude>**/.tycho-consumer-pom.xml</exclude>
                   <exclude>.github/**/*</exclude> <!-- GitHub config/template files -->
                   <exclude>release.properties</exclude> <!-- generated file -->

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
   <!-- *  V E R S I O N S                            -->
   <!-- *  most inherited from apache-wide parent pom -->
   <!-- ============================================= -->
-    <maven.version>3.2.2</maven.version>
+    <maven.version>3.6.3</maven.version>
     <!-- Tycho requires at least Java 11 -->
     <javaVersionMinBuild>11</javaVersionMinBuild>
     <felix.bundle.version>3.3.0</felix.bundle.version>
@@ -229,25 +229,25 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.16.0</version>
+          <version>3.19.0</version>
         </plugin>
       
         <plugin>
           <groupId>org.apache.uima</groupId>
           <artifactId>PearPackagingMavenPlugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
       
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
-          <version>0.15.7</version>
+          <version>0.17.1</version>
           <dependencies>
             <dependency>
               <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-jsr223</artifactId>
-              <version>2.5.17</version>
+              <version>2.5.20</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -255,7 +255,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.0.0</version>
+          <version>4.7.3.0</version>
         </plugin>
       
         <plugin>
@@ -267,31 +267,31 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>1.7.0</version>
+          <version>3.0.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>1.12.2</version>
+          <version>1.13.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.0.0</version>
           <configuration> 
             <!-- https://issues.apache.org/jira/browse/UIMA-5367 -->
             <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
@@ -321,7 +321,7 @@
              warning message to use install instead -->
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -348,7 +348,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.4</version>
+          <version>3.7.0</version>
           <executions>
             <execution>
               <!-- force to use process-classes phase so runs after Java Annotations are available -->
@@ -385,7 +385,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.4.1</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <!-- https://issues.apache.org/jira/browse/UIMA-5369 -->
@@ -437,7 +437,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.3.0</version>
           <configuration>
             <archive>
               <manifestEntries>
@@ -485,7 +485,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.6</version>
+          <version>5.1.8</version>
           <extensions>true</extensions>
           <executions>
             <execution>
@@ -501,7 +501,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.13</version>
+          <version>0.15</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -594,7 +594,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-eclipse-plugin</artifactId>
+          <version>2.10</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -605,7 +611,7 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-versions</id>
+            <id>enforce-maven-version</id>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -614,6 +620,16 @@
                 <requireMavenVersion>
                   <version>${maven.version}</version>
                 </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
                 <requireJavaVersion>
                   <version>${javaVersionMinBuild}</version>
                 </requireJavaVersion>
@@ -1479,7 +1495,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-eclipse-plugin</artifactId>
-              <!--  version set in parent-pom-top -->
               <configuration>
                 <manifest>.ignore</manifest>
                 <pde>true</pde>
@@ -2990,7 +3005,7 @@
       </activation>
       
       <properties>
-        <tycho-version>2.7.4</tycho-version>
+        <tycho-version>3.0.1</tycho-version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>26</version>
+    <version>29</version>
     <relativePath />
   </parent>
 
@@ -267,7 +267,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.0.0</version>
+          <!-- https://issues.apache.org/jira/browse/MPOM-344?focusedCommentId=17656127&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17656127 -->
+          <version>1.7.0</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
**What's in the PR**
- Minimum Maven version 3.2.2 -> 3.6.3
- maven-pmd-plugin 3.16.0 -> 3.19.0
- PearPackagingMavenPlugin 3.3.0 -> 3.3.1
- japicmp-maven-plugin 0.15.7 -> 0.17.1
- groovy-jsr223 2.5.17 -> 2.5.20
- spotbugs-maven-plugin 4.7.0.0 -> 4.7.3.0
- maven-remote-resources-plugin 1.7.0 -> 3.0.0
- maven-dependency-plugin 3.3.0 -> 3.4.0
- maven-scm-plugin 1.12.2 -> 1.13.0
- maven-resources-plugin 3.2.0 -> 3.3.0
- maven-deploy-plugin 2.8.2 -> 3.0.0
- maven-assembly-plugin 3.3.0 -> 3.4.2
- maven-plugin-plugin 3.6.4 -> 3.7.0
- maven-javadoc-plugin 3.4.0 -> 3.4.1
- maven-jar-plugin 3.2.2 -> 3.3.0
- maven-bundle-plugin 5.1.6 -> 5.1.8
- apache-rat-plugin 0.13 -> 0.15
- maven-enforcer-plugin 3.0.0 -> 3.1.0
- maven-eclipse-plugin -> 2.10
- tycho 2.7.4 -> 3.0.1
- split up enforcer plugin configuration to properly override the executions inherited from the parent pom
- Tycho 3 requires Java 17 for builds
- Add `.gitattributes` to rat plugin ignore list

**How to test manually**
* Run a build / release of a downstream product

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
