### PR TITLE
Issue #48: Antrun executions for gpg should be skipped as well when skipping GPG is requested

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
     <felix.bundle.version>3.3.0</felix.bundle.version>
 
     <maven.surefire.heap>512m</maven.surefire.heap>
+    
+    <gpg.skip>false</gpg.skip>
   </properties>
 
   <repositories>
@@ -878,6 +880,7 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
+                  <skip>${gpg.skip}</skip>
                   <target>
                     <taskdef name="if" classname="net.sf.antcontrib.logic.IfTask" />
                     <property name="source-release" location="${project.build.directory}/${project.artifactId}-${project.version}-source-release.zip" />


### PR DESCRIPTION
**What's in the PR**
- Skip GPG antrun execution based on gpg.skip parameter

**How to test manually**
* Run build e.g. of Apache UIMA Java SDK with `-Dgpg.skip` on a system without gpg

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
