### PR TITLE
Issue #37: RC auto staging checks out SVN even on non-release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,4 @@
   
 @Library('uima-build-jenkins-shared-library') _
 
-defaultPipeline {
-  extraMavenArguments = '-Prun-rat-report -Ddisable-rc-auto-staging -Ddisable-generate-release-notes'
-}
+defaultPipeline {}

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,15 @@
 
     <maven.surefire.heap>512m</maven.surefire.heap>
     
+    <maven.groovy.version>4.0.15</maven.groovy.version>
+    <maven.ant.version>1.10.14</maven.ant.version>
+    
     <gpg.skip>false</gpg.skip>
+
+    <!-- Disable release staging when not performing release build -->
+    <!-- Better solution would be a skip parameter - https://issues.apache.org/jira/browse/SCM-1013 -->
+    <releaseStagingCheckoutPhase>none</releaseStagingCheckoutPhase>
+    <releaseStagingCommitPhase>none</releaseStagingCommitPhase>
   </properties>
 
   <repositories>
@@ -190,13 +198,13 @@
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
-          <version>0.17.2</version>
+          <version>0.18.1</version>
           <dependencies>
             <dependency>
               <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-jsr223</artifactId>
-              <version>2.5.17</version>
+              <version>3.0.19</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -420,16 +428,28 @@
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.1.0</version>
           <dependencies>
-            <dependency> <!-- for ant extension supporting "if" -->
+            <dependency> 
+              <!-- for ant extension supporting "if" -->
               <groupId>ant-contrib</groupId>
               <artifactId>ant-contrib</artifactId>
               <version>20020829</version>
             </dependency>
-            <!-- <containsregexp> form for filesets -->
             <dependency>
               <groupId>org.apache.ant</groupId>
+              <artifactId>ant</artifactId>
+              <version>${maven.ant.version}</version>
+            </dependency>
+            <dependency>
+              <!-- <containsregexp> form for filesets -->
+              <groupId>org.apache.ant</groupId>
               <artifactId>ant-apache-regexp</artifactId>
-              <version>1.10.12</version>
+              <version>${maven.ant.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy-all</artifactId>
+              <version>${maven.groovy.version}</version>
+              <type>pom</type>
             </dependency>
           </dependencies>
         </plugin>
@@ -533,9 +553,9 @@
           <version>2.1.1</version>
           <dependencies>
             <dependency>
-              <groupId>org.codehaus.groovy</groupId>
+              <groupId>org.apache.groovy</groupId>
               <artifactId>groovy-all</artifactId>
-              <version>3.0.18</version>
+              <version>${maven.groovy.version}</version>
               <type>pom</type>
             </dependency>
           </dependencies>
@@ -720,6 +740,8 @@
       <id>apache-release</id>
       <properties>
         <isApacheRelease>true</isApacheRelease>
+        <releaseStagingCheckoutPhase>initialize</releaseStagingCheckoutPhase>
+        <releaseStagingCommitPhase>deploy</releaseStagingCommitPhase>
       </properties>
 
       <build>
@@ -1023,51 +1045,42 @@
                 <configuration>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
-                    <echo level="info">Generating release notes using GitHub API via the gh CLI tool</echo>
-                    <echo level="info">Repository : ${github-repository}</echo>
-                    <echo level="info">New tag    : ${project.artifactId}-${project.version}</echo>
-                    <echo level="info">Old tag    : rel/${project.artifactId}-${previous-release-version}</echo>
-                    <echo level="info">Branch     : ${git-branch}</echo>
-                    <mkdir dir="issuesFixed"/>
-                    <exec executable="gh" failonerror="true" outputproperty="gh-release-notes">
-                      <arg value="api" />
-                      <arg value="--method" />
-                      <arg value="POST" />
-                      <arg value="-H" />
-                      <arg value="Accept: application/vnd.github+json" />
-                      <arg value="-H" />
-                      <arg value="X-GitHub-Api-Version: 2022-11-28" />
-                      <arg value="/repos/apache/${github-repository}/releases/generate-notes" />
-                      <arg value="-f" />
-                      <arg value="tag_name=${project.artifactId}-${project.version}" />
-                      <arg value="-f" />
-                      <arg value="target_commitish=${git-branch}" />
-                      <arg value="-f" />
-                      <arg value="previous_tag_name=rel/${project.artifactId}-${previous-release-version}" />
-                    </exec>
+                    <sequential xmlns:if="ant:if" if:set="isApacheRelease">
+                      <echo level="info">Generating release notes using GitHub API via the gh CLI tool</echo>
+                      <echo level="info">Repository : ${github-repository}</echo>
+                      <echo level="info">New tag    : ${project.artifactId}-${project.version}</echo>
+                      <echo level="info">Old tag    : rel/${project.artifactId}-${previous-release-version}</echo>
+                      <echo level="info">Branch     : ${git-branch}</echo>
+                      <mkdir dir="issuesFixed"/>
+                      <exec executable="gh" failonerror="true" outputproperty="gh-release-notes">
+                        <arg value="api" />
+                        <arg value="--method" />
+                        <arg value="POST" />
+                        <arg value="-H" />
+                        <arg value="Accept: application/vnd.github+json" />
+                        <arg value="-H" />
+                        <arg value="X-GitHub-Api-Version: 2022-11-28" />
+                        <arg value="/repos/apache/${github-repository}/releases/generate-notes" />
+                        <arg value="-f" />
+                        <arg value="tag_name=${project.artifactId}-${project.version}" />
+                        <arg value="-f" />
+                        <arg value="target_commitish=${git-branch}" />
+                        <arg value="-f" />
+                        <arg value="previous_tag_name=rel/${project.artifactId}-${previous-release-version}" />
+                      </exec>
+                      <script language="groovy">
+                        <![CDATA[
+                          import groovy.json.JsonSlurper
+                          def jsonSlurper = new JsonSlurper()
+                          def json = jsonSlurper.parseText(project.properties['gh-release-notes'])
+                          new File('issuesFixed/github-report.md').withWriter("UTF-8") { out -> out.write(json.body) } 
+                        ]]>
+                      </script>
+                    </sequential>
+                    <sequential xmlns:unless="ant:unless" unless:set="iisApacheRelease">
+                      <echo level="info">Not generating release notes - this is not a release build</echo>
+                    </sequential>
                   </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.gmaven</groupId>
-            <artifactId>groovy-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- Load postNoticeText from NOTICE file -->
-                <id>gh-store-release-notes</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>execute</goal>
-                </goals>
-                <configuration>
-                  <source><![CDATA[
-                    import groovy.json.JsonSlurper
-                    def jsonSlurper = new JsonSlurper()
-                    def json = jsonSlurper.parseText(project.properties['gh-release-notes'])
-                    new File('issuesFixed/github-report.md').withWriter("UTF-8") { out -> out.write(json.body) } 
-                  ]]></source>
                 </configuration>
               </execution>
             </executions>
@@ -1943,7 +1956,7 @@
             <executions>
               <execution>
                 <id>checkout-staging</id>
-                <phase>initialize</phase>
+                <phase>${releaseStagingCheckoutPhase}</phase>
                 <goals>
                   <goal>checkout</goal>
                 </goals>
@@ -1955,7 +1968,7 @@
               </execution>
               <execution>
                 <id>add-staging-files</id>
-                <phase>deploy</phase>
+                <phase>${releaseStagingCommitPhase}</phase>
                 <goals>
                   <goal>add</goal>
                 </goals>
@@ -1968,7 +1981,7 @@
               </execution>
               <execution>
                 <id>commit-staging-files</id>
-                <phase>deploy</phase>
+                <phase>${releaseStagingCommitPhase}</phase>
                 <goals>
                   <goal>checkin</goal>
                 </goals>


### PR DESCRIPTION
**What's in the PR**
- Remove extra parameters from Jenkinsfile - no longer needed
- Upgrade to Groovy 4.0.15 except japicmp which requires Groovy 3.0.x
- japicmp-maven-plugin 0.17.2 -> 0.18.1
- Only generate release notes as part of a release build
- Only execute RC staging stuff when running as part of a release build
- Allow using Groovy script in antrun targets

**How to test manually**
* Run normal build which should not generate release notes and rc staging
* Run simulated release build which should generate release notes and do rc staging

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
