### PR TITLE
Issue #64: Update plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>29</version>
+    <version>33</version>
     <relativePath />
   </parent>
 
@@ -130,8 +130,8 @@
 
     <maven.surefire.heap>512m</maven.surefire.heap>
     
-    <maven.groovy.version>4.0.15</maven.groovy.version>
-    <maven.ant.version>1.10.14</maven.ant.version>
+    <maven.groovy.version>4.0.23</maven.groovy.version>
+    <maven.ant.version>1.10.15</maven.ant.version>
     
     <gpg.skip>false</gpg.skip>
 
@@ -168,13 +168,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.8.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
         </plugin>
 
         <plugin>
@@ -186,57 +186,49 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.10</version>
+          <version>0.8.12</version>
         </plugin>
       
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.21.0</version>
+          <version>3.25.0</version>
         </plugin>
       
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
-          <version>0.18.1</version>
-          <dependencies>
-            <dependency>
-              <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
-              <groupId>org.codehaus.groovy</groupId>
-              <artifactId>groovy-jsr223</artifactId>
-              <version>3.0.19</version>
-            </dependency>
-          </dependencies>
+          <version>0.23.0</version>
         </plugin>
         
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.3.5</version>
+          <version>4.8.6.4</version>
         </plugin>
       
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.6</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.8.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>2.0.1</version>
+          <version>2.1.0</version>
         </plugin>
 
         <plugin>
@@ -248,7 +240,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
           <configuration> 
             <!-- https://issues.apache.org/jira/browse/UIMA-5367 -->
             <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
@@ -258,19 +250,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
@@ -285,7 +277,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.1</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -301,19 +293,19 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.6.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.15.0</version>
           <executions>
             <execution>
               <!-- force to use process-classes phase so runs after Java Annotations are available -->
@@ -338,19 +330,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-toolchains-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.10.0</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <!-- https://issues.apache.org/jira/browse/UIMA-5369 -->
@@ -383,6 +375,11 @@
                 <name>pre</name>
                 <placement>X</placement>
               </tag>
+              <tag>
+                <name>forRemoval</name>
+                <placement>a</placement>
+                <head>To be removed in version:</head>
+              </tag>
             </tags>
           </configuration>
           <executions>
@@ -402,7 +399,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <archive>
               <manifestEntries>
@@ -473,7 +470,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.15</version>
+          <version>0.16.1</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -536,15 +533,9 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.uima</groupId>
-          <artifactId>uima-build-helper-maven-plugin</artifactId>
-          <version>7</version>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
         </plugin>
         
         <plugin>
@@ -616,31 +607,6 @@
             </goals>
             <configuration>
               <propertyPrefix>parsedVersion</propertyPrefix>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.uima</groupId>
-        <artifactId>uima-build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>set buildYear and buildMonth</id>
-            <goals>
-              <goal>parse-date-time</goal>
-            </goals>
-            <configuration>
-              <parseSpecs>
-                <parseSpec>
-                  <name>buildYear</name>
-                  <format>yyyy</format>
-                </parseSpec>
-                <parseSpec>
-                  <name>buildMonth</name>
-                  <format>MMMM</format>
-                </parseSpec>
-              </parseSpecs>
             </configuration>
           </execution>
         </executions>
@@ -1238,25 +1204,6 @@
                 </archive>
               </configuration>
             </plugin>
-    
-            <!-- special eclipse:eclipse configuration for Eclipse plugins -->
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-eclipse-plugin</artifactId>
-              <configuration>
-                <manifest>.ignore</manifest>
-                <pde>true</pde>
-                <!-- set next to false because refs to runtime project
-                     as a project don't work (because it is a library project,
-                     and has no sources of its own 
-                  
-                  A consequence of this: If you change code a plugin depends on,
-                  run "mvn install" on the changed code to get your plugin to
-                  pick up the changes 
-                  -->
-                <useProjectReferences>false</useProjectReferences>
-              </configuration>
-            </plugin>
           </plugins>
         </pluginManagement>
 
@@ -1399,23 +1346,6 @@
                       </pluginExecutionFilter>
                       <action>
                         <ignore />
-                      </action>
-                    </pluginExecution>
-                    
-                    <!-- ***************************** -->
-                    <!-- EXECUTE parse-date-time       -->
-                    <!-- ***************************** -->
-                    <pluginExecution>
-                      <pluginExecutionFilter>
-                        <groupId>org.apache.uima</groupId>
-                        <artifactId>uima-build-helper-maven-plugin</artifactId>
-                        <versionRange>[2,)</versionRange>
-                        <goals>
-                          <goal>parse-date-time</goal>
-                        </goals>
-                      </pluginExecutionFilter>
-                      <action>
-                        <execute />
                       </action>
                     </pluginExecution>
                     
@@ -1793,7 +1723,7 @@
       </activation>
       
       <properties>
-        <tycho-version>4.0.1</tycho-version>
+        <tycho-version>4.0.9</tycho-version>
       </properties>
     </profile>
 


### PR DESCRIPTION
**What's in the PR**
- Apache Parent POM 29 -> 33
- groovy 4.0.15 > 4.0.23
- ant 1.10.14 -> 1.10.15
- maven-invoker-plugin 3.6.0 -> 3.8.0
- maven-clean-plugin 3.3.1 -> 3.4.0
- jacoco-maven-plugin 0.8.10 -> 0.8.12
- maven-pmd-plugin 3.21.0 -> 3.25.0
- japicmp-maven-plugin 0.18.1 -> 0.23.0
- spotbugs-maven-plugin 4.7.3.5 -> 4.8.6.4
- maven-gpg-plugin 3.10.0 -> 3.2.6
- maven-remote-resources-plugin 3.1.0 -> 3.2.0
- maven-dependency-plugin 3.6.0 -> 3.8.0
- maven-scm-plugin 2.0.1 -> 2.1.0
- maven-deploy-plugin 3.1.1 -> 3.1.3
- maven-source-plugin 3.3.0 -> 3.3.1
- maven-surefire-plugin 3.1.2 -> 3.5.0
- maven-failsafe-plugin 3.1.2 -> 3.5.0
- maven-assembly-plugin 3.6.0 -> 3.7.1
- build-helper-maven-plugin 3.4.0 -> 3.6.0
- buildnumber-maven-plugin 3.2.0 -> 3.2.1
- maven-plugin-plugin 3.9.0 -> 3.15.0
- maven-toolchains-plugin 3.1.0 -> 3.2.0
- maven-compiler-plugin 3.11.0 -> 3.13.0
- maven-javadoc-plugin 3.5.0 -> 3.10.0
- maven-jar-plugin 3.3.0 -> 3.4.2
- apache-rat-plugin 0.15 -> 0.16.1
- uima-build-helper-maven-plugin -> removed
- maven-enforder-plugin 3.3.0 -> 3.5.0
- tycho 4.0.1 -> 4.0.9

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
