### PR TITLE
Issue #72: Upgrade plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>33</version>
+    <version>37</version>
     <relativePath />
   </parent>
 
@@ -130,7 +130,7 @@
 
     <maven.surefire.heap>512m</maven.surefire.heap>
     
-    <maven.groovy.version>4.0.23</maven.groovy.version>
+    <maven.groovy.version>5.0.4</maven.groovy.version>
     <maven.ant.version>1.10.15</maven.ant.version>
     
     <gpg.skip>false</gpg.skip>
@@ -168,13 +168,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.9.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
@@ -186,61 +186,61 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
+          <version>0.8.14</version>
         </plugin>
       
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.25.0</version>
+          <version>3.28.0</version>
         </plugin>
       
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
-          <version>0.23.0</version>
+          <version>0.25.4</version>
         </plugin>
         
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.8.6.4</version>
+          <version>4.9.8.2</version>
         </plugin>
       
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.2.7</version>
+          <version>3.2.8</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.10.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.2.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.3</version>
+          <version>3.1.4</version>
           <configuration> 
             <!-- https://issues.apache.org/jira/browse/UIMA-5367 -->
             <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
@@ -250,19 +250,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.5.5</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.5.5</version>
         </plugin>
 
         <plugin>
@@ -277,7 +277,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.7.1</version>
+          <version>3.8.0</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -293,19 +293,19 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.15.0</version>
+          <version>3.15.2</version>
           <executions>
             <execution>
               <!-- force to use process-classes phase so runs after Java Annotations are available -->
@@ -336,13 +336,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.15.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.12.0</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <!-- https://issues.apache.org/jira/browse/UIMA-5369 -->
@@ -414,7 +414,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
           <configuration>
             <archive>
               <manifestEntries>
@@ -438,7 +438,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
           <dependencies>
             <dependency> 
               <!-- for ant extension supporting "if" -->
@@ -469,7 +469,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.9</version>
+          <version>6.0.2</version>
           <extensions>true</extensions>
           <executions>
             <execution>
@@ -485,7 +485,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.16.1</version>
+          <version>0.17</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -550,7 +550,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
         </plugin>
         
         <plugin>
@@ -1058,7 +1058,7 @@
                         ]]>
                       </script>
                     </sequential>
-                    <sequential xmlns:unless="ant:unless" unless:set="iisApacheRelease">
+                    <sequential xmlns:unless="ant:unless" unless:set="isApacheRelease">
                       <echo level="info">Not generating release notes - this is not a release build</echo>
                     </sequential>
                   </target>
@@ -1738,7 +1738,7 @@
       </activation>
       
       <properties>
-        <tycho-version>4.0.9</tycho-version>
+        <tycho-version>5.0.2</tycho-version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <maven.surefire.heap>512m</maven.surefire.heap>
     
     <maven.groovy.version>5.0.4</maven.groovy.version>
-    <maven.ant.version>1.10.15</maven.ant.version>
+    <maven.ant.version>1.10.17</maven.ant.version>
     
     <gpg.skip>false</gpg.skip>
 
@@ -168,7 +168,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.9.1</version>
+          <version>3.10.1</version>
         </plugin>
 
         <plugin>
@@ -186,7 +186,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.14</version>
+          <version>0.8.15</version>
         </plugin>
       
         <plugin>
@@ -198,13 +198,13 @@
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
-          <version>0.25.4</version>
+          <version>0.26.1</version>
         </plugin>
         
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.8.2</version>
+          <version>4.10.2.0</version>
         </plugin>
       
         <plugin>
@@ -222,7 +222,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.10.0</version>
+          <version>3.11.0</version>
         </plugin>
 
         <plugin>
@@ -485,7 +485,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.17</version>
+          <version>0.18</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -550,7 +550,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.2</version>
+          <version>3.6.3</version>
         </plugin>
         
         <plugin>
@@ -1738,7 +1738,7 @@
       </activation>
       
       <properties>
-        <tycho-version>5.0.2</tycho-version>
+        <tycho-version>5.0.3</tycho-version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>37</version>
+    <version>38</version>
     <relativePath />
   </parent>
 
@@ -165,12 +165,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.10.1</version>
-        </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
@@ -496,28 +490,29 @@
               <!-- default configuration -->
               <configuration>
                 <consoleOutput>true</consoleOutput>
-                <excludes>
-                  <exclude>**/.gitattributes</exclude>
-                  <exclude>**/.tycho-consumer-pom.xml</exclude>
-                  <exclude>.github/**/*</exclude> <!-- GitHub config/template files -->
-                  <exclude>release.properties</exclude> <!-- generated file -->
-                  <exclude>README*</exclude>
-                  <exclude>RELEASE_NOTES*</exclude>
-                  <exclude>issuesFixed/**</exclude> <!-- generated file -->
+                <outputFile>target/rat.txt</outputFile>
+                <inputExcludes>
+                  <inputExclude>**/.gitattributes</inputExclude>
+                  <inputExclude>**/.tycho-consumer-pom.xml</inputExclude>
+                  <inputExclude>.github/**/*</inputExclude> <!-- GitHub config/template files -->
+                  <inputExclude>release.properties</inputExclude> <!-- generated file -->
+                  <inputExclude>README*</inputExclude>
+                  <inputExclude>RELEASE_NOTES*</inputExclude>
+                  <inputExclude>issuesFixed/**</inputExclude> <!-- generated file -->
                   <!-- Maven profile trigger files -->
-                  <exclude>**/marker-file-identifying-*</exclude>
-                  <exclude>**/marker-file-enabling-*</exclude>
-                  <exclude>DEPENDENCIES</exclude>  <!-- generated file -->
-                  <exclude>**/MANIFEST.MF</exclude> <!-- MANIFEST.MF files cannot have comments -->
-                  <exclude>**/*.ppt</exclude> <!--  power point sources -->
-                  <exclude>**/*.sha512</exclude>
-                  <exclude>**/*.patch.txt</exclude>
-                  <exclude>**/.factorypath</exclude> <!-- Eclipse APT generated file -->
-                  <exclude>**/.idea/**</exclude> <!-- IDEA config files -->
-                  <exclude>**/.settings/**</exclude> <!-- Eclipse config files -->
-                  <exclude>**/.project</exclude> <!-- Eclipse config files -->
-                  <exclude>**/.classpath</exclude> <!-- Eclipse config files -->
-                </excludes>
+                  <inputExclude>**/marker-file-identifying-*</inputExclude>
+                  <inputExclude>**/marker-file-enabling-*</inputExclude>
+                  <inputExclude>DEPENDENCIES</inputExclude>  <!-- generated file -->
+                  <inputExclude>**/MANIFEST.MF</inputExclude> <!-- MANIFEST.MF files cannot have comments -->
+                  <inputExclude>**/*.ppt</inputExclude> <!--  power point sources -->
+                  <inputExclude>**/*.sha512</inputExclude>
+                  <inputExclude>**/*.patch.txt</inputExclude>
+                  <inputExclude>**/.factorypath</inputExclude> <!-- Eclipse APT generated file -->
+                  <inputExclude>**/.idea/**</inputExclude> <!-- IDEA config files -->
+                  <inputExclude>**/.settings/**</inputExclude> <!-- Eclipse config files -->
+                  <inputExclude>**/.project</inputExclude> <!-- Eclipse config files -->
+                  <inputExclude>**/.classpath</inputExclude> <!-- Eclipse config files -->
+                </inputExcludes>
               </configuration>
             </execution>
           </executions>
@@ -1630,9 +1625,9 @@
                 <execution>
                   <id>default-cli</id>
                   <configuration>
-                    <excludes combine.children="append">
-                      <exclude>**/api-change-report/**/*.*</exclude>
-                    </excludes>
+                    <inputExcludes combine.children="append">
+                      <inputExclude>**/api-change-report/**/*.*</inputExclude>
+                    </inputExcludes>
                   </configuration>
                 </execution>
               </executions>


### PR DESCRIPTION
**What's in the PR**
- ant 1.10.15 -> 1.10.17
- apache (parent) 33 -> 38
- apache-rat-plugin 0.16.1 -> 0.18
- build-helper-maven-plugin 3.6.0 -> 3.6.1
- buildnumber-maven-plugin 3.2.1 -> 3.3.0
- jacoco-maven-plugin 0.8.12 -> 0.8.15
- japicmp-maven-plugin 0.23.0 -> 0.26.1
- maven-antrun-plugin 3.1.0 -> 3.2.0
- maven-assembly-plugin 3.7.1 -> 3.8.0
- maven-bundle-plugin 5.1.9 -> 6.0.2
- maven-clean-plugin 3.4.0 -> 3.5.0
- maven-compiler-plugin 3.13.0 -> 3.15.0
- maven-dependency-plugin 3.8.0 -> 3.11.0
- maven-deploy-plugin 3.1.3 -> 3.1.4
- maven-enforcer-plugin 3.5.0 -> 3.6.3
- maven-failsafe-plugin 3.5.1 -> 3.5.5
- maven-gpg-plugin 3.2.7 -> 3.2.8
- maven-invoker-plugin 3.8.0 -> 3.10.1
- maven-jar-plugin 3.4.2 -> 3.5.0
- maven-javadoc-plugin 3.10.1 -> 3.12.0
- maven-plugin-plugin 3.15.0 -> 3.15.2
- maven-pmd-plugin 3.25.0 -> 3.28.0
- maven-remote-resources-plugin 3.2.0 -> 3.3.0
- maven-resources-plugin 3.3.1 -> 3.5.0
- maven-scm-plugin 2.1.0 -> 2.2.1
- maven-source-plugin 3.3.1 -> 3.4.0
- maven-surefire-plugin 3.5.1 -> 3.5.5
- maven.groovy 4.0.23 -> 5.0.4
- spotbugs-maven-plugin 4.8.6.4 -> 4.10.2.0
- tycho 4.0.9 -> 5.0.3

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
